### PR TITLE
v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.4] - 2024-08-13
-
 ## [0.2.4] - 2024-07-30
 
 ### Changed
 
 - `zonal_stats` now uses `xvec` instead of geocube.
+- default `EDS_API_URL` from [https://api.eds.earthdaily.com/archive/v1/stac/v1](https://api.eds.earthdaily.com/archive/v1/stac/v1) to 
+[https://api.earthdaily.com/platform/v1/stac](https://api.earthdaily.com/platform/v1/stac)
 
 
 ## [0.2.3] - 2024-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [0.2.4] - 2024-07-30
+## [0.2.4] - 2024-08-13
 
 ### Changed
 
-- `zonal_stats` now uses `xvec` instead of geocube.
+- `zonal_stats` now uses homemade `numpy` method. Per default `smart_load` is
+set to `True` in the accessor to load in memory the maximum of dates.
 
 
 ## [0.2.3] - 2024-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.4] - 2024-07-30
+## [0.2.4] - 2024-08-13
 
 ### Changed
 

--- a/earthdaily/__init__.py
+++ b/earthdaily/__init__.py
@@ -7,7 +7,7 @@ from .accessor import EarthDailyAccessorDataArray, EarthDailyAccessorDataset
 # to hide warnings from rioxarray or nano seconds conversion
 # warnings.filterwarnings("ignore")
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 
 def EarthDataStore(

--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -255,7 +255,7 @@ def _get_token(config=None):
     auth_url = config("EDS_AUTH_URL")
     secret = config("EDS_SECRET")
     client_id = config("EDS_CLIENT_ID")
-    eds_url = config("EDS_API_URL", "https://api.eds.earthdaily.com/archive/v1/stac/v1")
+    eds_url = config("EDS_API_URL", "https://api.earthdaily.com/platform/v1/stac")
     if auth_url is None or secret is None or client_id is None:
         raise AttributeError(
             "You need to have env : EDS_AUTH_URL, EDS_SECRET and EDS_CLIENT_ID"

--- a/earthdaily/earthdatastore/mask/__init__.py
+++ b/earthdaily/earthdatastore/mask/__init__.py
@@ -137,8 +137,7 @@ class Mask:
         self._obj = self._obj.assign_coords(
             {"clear_pixels": ("time", n_pixels_as_labels.data)}
         )
-        
-        
+
         self._obj = self._obj.assign_coords(
             {
                 "clear_percent": (

--- a/earthdaily/earthdatastore/mask/__init__.py
+++ b/earthdaily/earthdatastore/mask/__init__.py
@@ -137,13 +137,14 @@ class Mask:
         self._obj = self._obj.assign_coords(
             {"clear_pixels": ("time", n_pixels_as_labels.data)}
         )
-
+        
+        
         self._obj = self._obj.assign_coords(
             {
                 "clear_percent": (
                     "time",
                     np.multiply(
-                        self._obj["n_pixels_as_labels"]
+                        self._obj["clear_pixels"].data
                         / self._obj.attrs["usable_pixels"],
                         100,
                     ).astype(np.int8),

--- a/examples/field_evolution.py
+++ b/examples/field_evolution.py
@@ -62,6 +62,6 @@ plt.show()
 zonal_stats = pivot_cube.ed.zonal_stats(pivot, ['mean','max','min'])
 
 zonal_stats.isel(feature=0).to_array(dim="band").plot.line(
-    x="time", col="band", hue="stats", col_wrap=3
+    x="time", col="band", hue="zonal_statistics", col_wrap=3
 )
 plt.show()


### PR DESCRIPTION
## [0.2.4] - 2024-08-13

### Changed

- `zonal_stats` now uses `xvec` instead of geocube.
- default `EDS_API_URL` from [https://api.eds.earthdaily.com/archive/v1/stac/v1](https://api.eds.earthdaily.com/archive/v1/stac/v1) to 
[https://api.earthdaily.com/platform/v1/stac](https://api.earthdaily.com/platform/v1/stac)
