### PR TITLE
v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2024-08-29
+
+### Fixed
+
+- `intersects` computation now uses only the geometry field in order to avoid 
+json parsing error.
+
 ## [0.2.5] - 2024-08-28
 
 ### Added

--- a/earthdaily/__init__.py
+++ b/earthdaily/__init__.py
@@ -7,7 +7,7 @@ from .accessor import EarthDailyAccessorDataArray, EarthDailyAccessorDataset
 # to hide warnings from rioxarray or nano seconds conversion
 # warnings.filterwarnings("ignore")
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 
 def EarthDataStore(

--- a/earthdaily/earthdatastore/cube_utils/geometry_manager.py
+++ b/earthdaily/earthdatastore/cube_utils/geometry_manager.py
@@ -13,9 +13,9 @@ class GeometryManager:
         return self._obj
 
     def to_intersects(self, crs="EPSG:4326"):
-        return json.loads(self._obj.to_crs(crs).dissolve().geometry.to_json(drop_id=True))[
-            "features"
-        ][0]["geometry"]
+        return json.loads(
+            self._obj.to_crs(crs).dissolve().geometry.to_json(drop_id=True)
+        )["features"][0]["geometry"]
 
     def to_wkt(self, crs="EPSG:4326"):
         wkts = list(self._obj.to_crs(crs=crs).to_wkt()["geometry"])

--- a/earthdaily/earthdatastore/cube_utils/geometry_manager.py
+++ b/earthdaily/earthdatastore/cube_utils/geometry_manager.py
@@ -14,7 +14,7 @@ class GeometryManager:
 
     def to_intersects(self, crs="EPSG:4326"):
         return json.loads(
-            self._obj.to_crs(crs).dissolve().geometry.to_json(drop_id=True)
+            self._obj.to_crs(crs).dissolve().geometry.to_json(drop_id=False)
         )["features"][0]["geometry"]
 
     def to_wkt(self, crs="EPSG:4326"):

--- a/earthdaily/earthdatastore/cube_utils/geometry_manager.py
+++ b/earthdaily/earthdatastore/cube_utils/geometry_manager.py
@@ -13,7 +13,7 @@ class GeometryManager:
         return self._obj
 
     def to_intersects(self, crs="EPSG:4326"):
-        return json.loads(self._obj.to_crs(crs).dissolve().to_json(drop_id=True))[
+        return json.loads(self._obj.to_crs(crs).dissolve().geometry.to_json(drop_id=True))[
             "features"
         ][0]["geometry"]
 

--- a/earthdaily/earthdatastore/cube_utils/geometry_manager.py
+++ b/earthdaily/earthdatastore/cube_utils/geometry_manager.py
@@ -14,7 +14,7 @@ class GeometryManager:
 
     def to_intersects(self, crs="EPSG:4326"):
         return json.loads(
-            self._obj.to_crs(crs).dissolve().geometry.to_json(drop_id=False)
+            self._obj.to_crs(crs).dissolve().geometry.to_json()
         )["features"][0]["geometry"]
 
     def to_wkt(self, crs="EPSG:4326"):

--- a/earthdaily/earthdatastore/cube_utils/geometry_manager.py
+++ b/earthdaily/earthdatastore/cube_utils/geometry_manager.py
@@ -13,9 +13,9 @@ class GeometryManager:
         return self._obj
 
     def to_intersects(self, crs="EPSG:4326"):
-        return json.loads(
-            self._obj.to_crs(crs).dissolve().geometry.to_json()
-        )["features"][0]["geometry"]
+        return json.loads(self._obj.to_crs(crs).dissolve().geometry.to_json())[
+            "features"
+        ][0]["geometry"]
 
     def to_wkt(self, crs="EPSG:4326"):
         wkts = list(self._obj.to_crs(crs=crs).to_wkt()["geometry"])

--- a/tests/test_geometrymanager.py
+++ b/tests/test_geometrymanager.py
@@ -46,6 +46,7 @@ class TestGeometryManager(unittest.TestCase):
           ]
         }
         gM = geometry_manager.GeometryManager(geom)
+        
     def test_two_geometry_geojson(self):
         geom = {
           "type": "FeatureCollection",


### PR DESCRIPTION
## [0.2.6] - 2024-08-29

### Fixed

- `intersects` computation now uses only the geometry field in order to avoid 
json parsing error.
