### PR TITLE
[0.2.9] - 2024-09-24 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.9] - 2024-09-24
+
+### Fixed
+
+- `prefer_alternate` is set by default to `download` in datacube is order to 
+have presigned url.
+
 ## [0.2.8] - 2024-09-23
 
 ### Added

--- a/earthdaily/__init__.py
+++ b/earthdaily/__init__.py
@@ -7,7 +7,7 @@ from .accessor import EarthDailyAccessorDataArray, EarthDailyAccessorDataset
 # to hide warnings from rioxarray or nano seconds conversion
 # warnings.filterwarnings("ignore")
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 
 def EarthDataStore(

--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -1303,6 +1303,8 @@ class Auth:
         ids_ = [x for n in (items_id.values()) for x in n]
         items_list = []
         step = 100
+        kwargs.setdefault('prefer_alternate','download')
+
         for items_start_idx in range(0, len(ids_), step):
             items = self.search(
                 collections=collections,

--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -1303,7 +1303,7 @@ class Auth:
         ids_ = [x for n in (items_id.values()) for x in n]
         items_list = []
         step = 100
-        kwargs.setdefault('prefer_alternate','download')
+        kwargs.setdefault("prefer_alternate", "download")
 
         for items_start_idx in range(0, len(ids_), step):
             items = self.search(


### PR DESCRIPTION
## [0.2.9] - 2024-09-24

### Fixed

- `prefer_alternate` is set by default to `download` in datacube is order to 
have presigned url.