### PR TITLE
Introducing asset_proxy_enabled flag to ask for Asset Proxy URLs from EDA Platform STAC API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -27,6 +26,15 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -64,7 +72,6 @@ docs/_*
 target/
 
 # Auth
-.env
 .vscode/
 
 docs/html/.doctrees/

--- a/earthdaily/__init__.py
+++ b/earthdaily/__init__.py
@@ -16,6 +16,7 @@ def EarthDataStore(
     profile: Optional[str] = None,
     presign_urls: bool = True,
     request_payer: bool = False,
+    asset_proxy_enabled: bool = False,
 ) -> earthdatastore.Auth:
     """
     Open earth data store connection to allow for datacube requests.
@@ -34,6 +35,10 @@ def EarthDataStore(
     profile : profile, optional
         Name of the profile to use in the TOML file.
         Uses "default" by default.
+    asset_proxy_enabled : bool, optional
+        If True, the asset proxy URLs will be returned instead of pre-signed URLs.
+        Both asset_proxy_enabled and presign_urls cannot be True at the same time. asset_proxy_enabled takes precedence.
+        Uses False by default.
 
     Returns
     -------
@@ -46,4 +51,5 @@ def EarthDataStore(
         profile=profile,
         presign_urls=presign_urls,
         request_payer=request_payer,
+        asset_proxy_enabled=asset_proxy_enabled,
     )

--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -4,20 +4,16 @@ import operator
 import os
 import warnings
 import time
-import pandas as pd
 import geopandas as gpd
-import psutil
 import requests
 import xarray as xr
 import numpy as np
 from typing import Optional
 from pathlib import Path
 from pystac.item_collection import ItemCollection
-from pystac_client.item_search import ItemSearch
 from pystac_client import Client
 from pystac_client.stac_api_io import StacApiIO
 from urllib3 import Retry
-from itertools import chain
 from odc import stac
 from . import _scales_collections, cube_utils, mask
 from .parallel_search import parallel_search, NoItemsFoundError

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from earthdaily import EarthDataStore
+from earthdaily.earthdatastore import Auth
+
+
+class TestEarthDataStore(unittest.TestCase):
+    @patch("earthdaily.earthdatastore.Auth.from_credentials")
+    def test_asset_proxy_enabled(self, mock_from_credentials):
+        # Mock the return value of from_credentials
+        mock_auth_instance = MagicMock(spec=Auth)
+        mock_from_credentials.return_value = mock_auth_instance
+
+        # Call EarthDataStore with asset_proxy_enabled set to True
+        auth_instance = EarthDataStore(asset_proxy_enabled=True)
+
+        # Assert that from_credentials was called with asset_proxy_enabled=True
+        mock_from_credentials.assert_called_once_with(
+            json_path=None,
+            toml_path=None,
+            profile=None,
+            presign_urls=True,
+            request_payer=False,
+            asset_proxy_enabled=True,
+        )
+
+        # Assert that the returned instance is the mocked instance
+        self.assertEqual(auth_instance, mock_auth_instance)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
This PR introduces a new attribute `asset_proxy_enabled` to the `EarthDataStore` class.

### Changes

#### New Attribute:

Added the `asset_proxy_enabled` attribute to the `EarthDataStore` class to enable or disable asset proxy functionality.

#### Unit Tests:

Created a new test case in `test_client.py` to verify the new flag `asset_proxy_enabled` is not breaking the client instantiation.

#### Testing Manually:

```python
from earthdaily import EarthDataStore

eds = EarthDataStore(asset_proxy_enabled=True)

first_item = list(eds.search(collections=["ai-ready-mosaics-sample"], limit=1))[0]

asset_proxy_url = first_item.assets["thumbnail"].extra_fields["alternate"]["download"]["href"]
```

You should be able to see the asset proxy URL and interact with it.

This change is backward compatible and does not affect existing functionality.

##### Other small changes:

- Added a new section to the `.gitignore` file for ignoring the "Environments" as it was not complete. (inherited from here: https://github.com/github/gitignore/blob/main/Python.gitignore)
- Removed a couple of unused imports.