### PR TITLE
Exposing the get_access_token method and introducing EDSConfig Object

### DIFF
--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -2,26 +2,38 @@ import json
 import logging
 import operator
 import os
-import warnings
 import time
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
 import geopandas as gpd
+import numpy as np
 import requests
 import xarray as xr
-import numpy as np
-from typing import Optional
-from pathlib import Path
+from odc import stac
 from pystac.item_collection import ItemCollection
 from pystac_client import Client
 from pystac_client.stac_api_io import StacApiIO
 from urllib3 import Retry
-from odc import stac
+
 from . import _scales_collections, cube_utils, mask
-from .parallel_search import parallel_search, NoItemsFoundError
-from .cube_utils import datacube, metacube, _datacubes, asset_mapper
+from .cube_utils import _datacubes, asset_mapper, datacube, metacube
+from .parallel_search import NoItemsFoundError, parallel_search
 
 __all__ = ["datacube", "metacube", "xr", "stac"]
 
 logging.getLogger("earthdaily-earthdatastore")
+
+
+@dataclass
+class EarthDataStoreConfig:
+    auth_url: Optional[str] = None
+    client_secret: Optional[str] = None
+    client_id: Optional[str] = None
+    eds_url: str = "https://api.earthdaily.com/platform/v1/stac"
+    access_token: Optional[str] = None
 
 
 def apply_single_condition(
@@ -292,95 +304,6 @@ def enhance_assets(
                                 ]["nodata"] = scales_collection["nodata"]
 
     return items
-
-
-def _get_token(config=None):
-    """Get token for interacting with the Earth Data Store API.
-
-    By default, Earth Data Store will look for environment variables called
-    EDS_AUTH_URL, EDS_SECRET and EDS_CLIENT_ID.
-
-    Parameters
-    ----------
-    config : str | dict, optional
-        A JSON string or a dictionary with the credentials for the Earth Data Store.
-    presign_urls : bool, optional
-        Use presigned URLs, by default True
-
-    Returns
-    -------
-    token : str
-    eds_url : the earthdatastore url
-
-    """
-    if config is None:
-        config = os.getenv
-    auth_url = config("EDS_AUTH_URL")
-    secret = config("EDS_SECRET")
-    client_id = config("EDS_CLIENT_ID")
-    eds_url = config("EDS_API_URL", "https://api.earthdaily.com/platform/v1/stac")
-    if auth_url is None or secret is None or client_id is None:
-        raise AttributeError(
-            "You need to have env : EDS_AUTH_URL, EDS_SECRET and EDS_CLIENT_ID"
-        )
-
-    token_response = requests.post(
-        auth_url,
-        data={"grant_type": "client_credentials"},
-        allow_redirects=False,
-        auth=(client_id, secret),
-    )
-    token_response.raise_for_status()
-    return json.loads(token_response.text)["access_token"], eds_url
-
-
-def _get_client(config=None, presign_urls=True, asset_proxy_enabled=False):
-    """Get client for interacting with the Earth Data Store API.
-
-    By default, Earth Data Store will look for environment variables called
-    EDS_AUTH_URL, EDS_SECRET and EDS_CLIENT_ID.
-
-    Parameters
-    ----------
-    config : str | dict, optional
-        A JSON string or a dictionary with the credentials for the Earth Data Store.
-    presign_urls : bool, optional
-        Use presigned URLs, by default True
-    asset_proxy_enabled : bool, optional
-        Use asset proxy URLs, by default False
-
-    Returns
-    -------
-    client : Client
-        A PySTAC client for interacting with the Earth Data Store STAC API.
-
-    """
-
-    if isinstance(config, tuple):  # token
-        token, eds_url = config
-        logging.log(level=logging.INFO, msg="Using token to reauth")
-    else:
-        if isinstance(config, dict):
-            config = config.get
-        elif isinstance(config, str) and config.endswith(".json"):
-            config = json.load(open(config, "rb")).get
-        token, eds_url = _get_token(config)
-
-    headers = {"Authorization": f"bearer {token}"}
-    if asset_proxy_enabled:
-        headers["X-Proxy-Asset-Urls"] = "True"
-    elif presign_urls:
-        headers["X-Signed-Asset-Urls"] = "True"
-
-    retry = Retry(
-        total=5,
-        backoff_factor=1,
-        status_forcelist=[502, 503, 504],
-        allowed_methods=None,
-    )
-    stac_api_io = StacApiIO(max_retries=retry)
-
-    return Client.open(eds_url, headers=headers, stac_io=stac_api_io)
 
 
 class StacCollectionExplorer:
@@ -689,6 +612,135 @@ class Auth:
 
         return config
 
+    def get_access_token(self, config: Optional[EarthDataStoreConfig] = None):
+        """
+        Retrieve an access token for interacting with the EarthDataStore API.
+
+        By default, the method will look for environment variables:
+        EDS_AUTH_URL, EDS_SECRET, and EDS_CLIENT_ID. Alternatively, a configuration
+        object or dictionary can be passed to override these values.
+
+        Parameters
+        ----------
+        config : EarthDataStoreConfig, optional
+            A configuration object containing the Earth Data Store credentials.
+
+        Returns
+        -------
+        str
+            The access token for authenticating with the Earth Data Store API.
+        """
+        if not config:
+            config = self._config_parser(self.__auth_config)
+        response = requests.post(
+            config.auth_url,
+            data={"grant_type": "client_credentials"},
+            allow_redirects=False,
+            auth=(config.client_id, config.client_secret),
+        )
+        response.raise_for_status()
+        return response.json()["access_token"]
+
+    def _config_parser(self, config=None):
+        """
+        Parse and construct the EarthDataStoreConfig object from various input formats.
+
+        The method supports configuration as a dictionary, JSON file path, tuple,
+        or environment variables.
+
+        Parameters
+        ----------
+        config : dict or str or tuple, optional
+            Configuration source. It can be:
+            - A dictionary containing the required API credentials.
+            - A string path to a JSON file containing these credentials.
+            - A tuple of (access_token, eds_url).
+            - None, in which case environment variables will be used.
+
+        Returns
+        -------
+        EarthDataStoreConfig
+            A configuration object containing the required API credentials.
+
+        Raises
+        ------
+        AttributeError
+            If required credentials are missing in the provided input or environment variables.
+        """
+        if isinstance(config, tuple):  # token
+            access_token, eds_url = config
+            logging.log(level=logging.INFO, msg="Using token to reauth")
+            return EarthDataStoreConfig(eds_url=eds_url, access_token=access_token)
+        else:
+            if isinstance(config, dict):
+                config = config.get
+            elif isinstance(config, str) and config.endswith(".json"):
+                config = json.load(open(config, "rb")).get
+
+            if config is None:
+                config = os.getenv
+            auth_url = config("EDS_AUTH_URL")
+            client_secret = config("EDS_SECRET")
+            client_id = config("EDS_CLIENT_ID")
+            eds_url = config(
+                "EDS_API_URL", "https://api.earthdaily.com/platform/v1/stac"
+            )
+            if auth_url is None or client_secret is None or client_id is None:
+                raise AttributeError(
+                    "You need to have env : EDS_AUTH_URL, EDS_SECRET and EDS_CLIENT_ID"
+                )
+            return EarthDataStoreConfig(
+                auth_url=auth_url,
+                client_secret=client_secret,
+                client_id=client_id,
+                eds_url=eds_url,
+            )
+
+    def _get_client(self, config=None, presign_urls=True, asset_proxy_enabled=False):
+        """Get client for interacting with the EarthDataStore API.
+
+        By default, Earth Data Store will look for environment variables called
+        EDS_AUTH_URL, EDS_SECRET and EDS_CLIENT_ID.
+
+        Parameters
+        ----------
+        config : str | dict, optional
+            A JSON string or a dictionary with the credentials for the Earth Data Store.
+        presign_urls : bool, optional
+            Use presigned URLs, by default True
+        asset_proxy_enabled : bool, optional
+            Use asset proxy URLs, by default False
+
+        Returns
+        -------
+        client : Client
+            A PySTAC client for interacting with the Earth Data Store STAC API.
+
+        """
+
+        config = self._config_parser(config)
+
+        if config.access_token:
+            access_token = config.access_token
+        else:
+            access_token = self.get_access_token(config)
+
+        headers = {"Authorization": f"bearer {access_token}"}
+        if asset_proxy_enabled:
+            headers["X-Proxy-Asset-Urls"] = "True"
+        elif presign_urls:
+            headers["X-Signed-Asset-Urls"] = "True"
+
+        retry = Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=[502, 503, 504],
+            allowed_methods=None,
+        )
+        stac_api_io = StacApiIO(max_retries=retry)
+
+        return Client.open(config.eds_url, headers=headers, stac_io=stac_api_io)
+
     @property
     def client(self) -> Client:
         """
@@ -701,7 +753,7 @@ class Auth:
         if t := (time.time() - self.__time_eds_log) > 3600 or self._client is None:
             if t:
                 logging.log(level=logging.INFO, msg="Reauth to EarthDataStore")
-            self._client = _get_client(
+            self._client = self._get_client(
                 self.__auth_config, self.__presign_urls, self.__asset_proxy_enabled
             )
             self.__time_eds_log = time.time()

--- a/tests/test_eds_auth.py
+++ b/tests/test_eds_auth.py
@@ -13,7 +13,7 @@ class TestEdsAuth(unittest.TestCase):
     @patch("earthdaily.earthdatastore.Auth.read_credentials_from_json")
     def test_read_credentials_from_json(self, mock_read_json):
         mock_read_json.return_value = {
-            "EDS_AUTH_URL": "https://valid-auth-url.com",
+            "EDS_AUTH_URL": "https://auth.example.com",
             "EDS_SECRET": "secret_value",
             "EDS_CLIENT_ID": "client_id_value",
         }

--- a/tests/test_eds_auth.py
+++ b/tests/test_eds_auth.py
@@ -1,0 +1,155 @@
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+from earthdaily.earthdatastore import Auth, EarthDataStoreConfig
+
+
+class TestEdsAuth(unittest.TestCase):
+    def setUp(self):
+        self.auth_instance = Auth()
+
+    @patch("earthdaily.earthdatastore.Auth.read_credentials_from_json")
+    def test_read_credentials_from_json(self, mock_read_json):
+        mock_read_json.return_value = {
+            "EDS_AUTH_URL": "https://valid-auth-url.com",
+            "EDS_SECRET": "secret_value",
+            "EDS_CLIENT_ID": "client_id_value",
+        }
+        json_path = Path("/path/to/credentials.json")
+        credentials = Auth.read_credentials_from_json(json_path)
+        mock_read_json.assert_called_once_with(json_path)
+        self.assertEqual(credentials["EDS_AUTH_URL"], "https://auth.example.com")
+
+    @patch("earthdaily.earthdatastore.Auth.read_credentials_from_toml")
+    def test_read_credentials_from_toml(self, mock_read_toml):
+        mock_read_toml.return_value = {
+            "EDS_AUTH_URL": "https://auth.example.com",
+            "EDS_SECRET": "secret_value",
+            "EDS_CLIENT_ID": "client_id_value",
+        }
+        toml_path = Path("/path/to/credentials.toml")
+        credentials = Auth.read_credentials_from_toml(toml_path, profile="default")
+        mock_read_toml.assert_called_once_with(toml_path, profile="default")
+        self.assertEqual(credentials["EDS_SECRET"], "secret_value")
+
+    @patch("os.getenv")
+    def test_read_credentials_from_environment(self, mock_getenv):
+        mock_getenv.side_effect = lambda key: {
+            "EDS_AUTH_URL": "https://auth.example.com",
+            "EDS_SECRET": "secret_value",
+            "EDS_CLIENT_ID": "client_id_value",
+        }.get(key)
+        credentials = Auth.read_credentials_from_environment()
+        self.assertEqual(credentials["EDS_CLIENT_ID"], "client_id_value")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="[default]\nEDS_AUTH_URL=https://auth.example.com\nEDS_SECRET=secret_value\nEDS_CLIENT_ID=client_id_value")
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_read_credentials_from_ini(self, mock_exists, mock_open):
+        credentials = Auth.read_credentials_from_ini(profile="default")
+        self.assertEqual(credentials["EDS_AUTH_URL"], "https://auth.example.com")
+        self.assertEqual(credentials["EDS_SECRET"], "secret_value")
+        self.assertEqual(credentials["EDS_CLIENT_ID"], "client_id_value")
+
+    def test_parse_dict(self):
+        config = {
+            "EDS_AUTH_URL": "https://auth.example.com",
+            "EDS_SECRET": "secret_value",
+            "EDS_CLIENT_ID": "client_id_value",
+        }
+        result = self.auth_instance._config_parser(config=config)
+        self.assertIsInstance(result, EarthDataStoreConfig)
+        self.assertEqual(result.auth_url, "https://auth.example.com")
+        self.assertEqual(result.client_secret, "secret_value")
+        self.assertEqual(result.client_id, "client_id_value")
+
+    @patch("builtins.open", new_callable=mock_open, read_data=json.dumps({
+        "EDS_AUTH_URL": "https://auth.example.com",
+        "EDS_SECRET": "secret_value",
+        "EDS_CLIENT_ID": "client_id_value"
+    }))
+    def test_parse_json_file(self, mock_open_file):
+        result = self.auth_instance._config_parser(config="path/to/credentials.json")
+        self.assertIsInstance(result, EarthDataStoreConfig)
+        self.assertEqual(result.auth_url, "https://auth.example.com")
+        self.assertEqual(result.client_secret, "secret_value")
+        self.assertEqual(result.client_id, "client_id_value")
+        mock_open_file.assert_called_once_with("path/to/credentials.json", "rb")
+
+    def test_parse_tuple(self):
+        config = ("mock_access_token", "https://api.example.com")
+        result = self.auth_instance._config_parser(config=config)
+        self.assertIsInstance(result, EarthDataStoreConfig)
+        self.assertEqual(result.access_token, "mock_access_token")
+        self.assertEqual(result.eds_url, "https://api.example.com")
+
+    @patch("os.getenv")
+    def test_parse_from_environment(self, mock_getenv):
+        mock_getenv.side_effect = lambda key, default=None: {
+            "EDS_AUTH_URL": "https://auth.example.com",
+            "EDS_SECRET": "secret_value",
+            "EDS_CLIENT_ID": "client_id_value",
+            "EDS_API_URL": "https://api.example.com",
+        }.get(key, default)
+        result = self.auth_instance._config_parser()
+        self.assertIsInstance(result, EarthDataStoreConfig)
+        self.assertEqual(result.auth_url, "https://auth.example.com")
+        self.assertEqual(result.client_secret, "secret_value")
+        self.assertEqual(result.client_id, "client_id_value")
+        self.assertEqual(result.eds_url, "https://api.example.com")
+
+    def test_missing_credentials(self):
+        with self.assertRaises(AttributeError) as context:
+            self.auth_instance._config_parser(config={})
+        self.assertIn("You need to have env : EDS_AUTH_URL, EDS_SECRET and EDS_CLIENT_ID", str(context.exception))
+
+    @patch("requests.post")
+    def test_get_access_token(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "mock_access_token"}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        config = EarthDataStoreConfig(
+            auth_url="https://auth.example.com",
+            client_secret="secret_value",
+            client_id="client_id_value",
+        )
+
+        token = self.auth_instance.get_access_token(config=config)
+
+        mock_post.assert_called_once_with(
+            "https://auth.example.com",
+            data={"grant_type": "client_credentials"},
+            allow_redirects=False,
+            auth=("client_id_value", "secret_value"),
+        )
+        self.assertEqual(token, "mock_access_token")
+
+    @patch("earthdaily.earthdatastore.Auth._get_client")
+    @patch("earthdaily.earthdatastore.Auth.read_credentials")
+    def test_from_credentials(self, mock_read_credentials, mock_get_client):
+        mock_read_credentials.return_value = {
+            "EDS_AUTH_URL": "https://auth.example.com",
+            "EDS_SECRET": "secret_value",
+            "EDS_CLIENT_ID": "client_id_value",
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "mock_access_token"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_get_client.return_value = MagicMock()
+
+        auth_instance = Auth.from_credentials(json_path=Path("/path/to/credentials.json"))
+
+        self.assertIsInstance(auth_instance, Auth)
+        self.assertEqual(auth_instance._Auth__auth_config["EDS_CLIENT_ID"], "client_id_value")
+        self.assertEqual(auth_instance._Auth__auth_config["EDS_SECRET"], "secret_value")
+        self.assertEqual(auth_instance._Auth__auth_config["EDS_AUTH_URL"], "https://auth.example.com")
+
+        mock_get_client.assert_called_once()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary

Exposing the `get_access_token` to the external users, so they could access the `access_token` for downloading assets behind the proxy URL.

Refactored the auth-related methods to reuse the code instead of writing from scratch.

Introduced a new `EarthDataStoreCofnig`  data class, useful for organizing configuration variables.

Changes

- `get_access_token` is available from the EarthDataStore object.

```python
from earthdaily import EarthDataStore

eds = EarthDataStore()

access_token = eds.get_access_token()
```

It could also be used by the internal `get_client` method to init the PySTAC client object.

All of the changes here are backward compatible and must not break any current interfaces.

- Added a new set of unit tests to test the Auth class.

Still keeping the old unit tests, just to be safe, but happy to refactor them in the future.

- Added a new `dataclass` called `EarthDataStoreCofnig`

Being used internally for now but we could think about exposing it to the end user in the future.

closes #142 