### PR TITLE
Fix/pystac-client max_retries issue  with v0.6.1 #153

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "joblib",
         "scipy",
         "psutil",
-        "pystac-client",
+        "pystac-client>=0.7.0",
         "pystac",
         "odc-stac",
         "pandas>=2",

--- a/tests/test_zonalstats.py
+++ b/tests/test_zonalstats.py
@@ -1,6 +1,5 @@
 import numpy as np
 import xarray as xr
-import rioxarray as rxr
 import geopandas as gpd
 from shapely.geometry import Polygon
 import earthdaily
@@ -44,7 +43,7 @@ class TestZonalStats(unittest.TestCase):
 
     def test_basic(self):
         zonalstats = earthdaily.earthdatastore.cube_utils.zonal_stats(
-            self.datacube, self.gdf, method="numpy", reducers=["min", "max"], all_touched=False, label="label")
+            self.datacube, self.gdf, method="numpy", reducers=["min", "max"], all_touched=False)
         for operation in ["min", "max"]:
             self._check_results(
                 zonalstats["first_var"].sel(zonal_statistics=operation).values, operation=operation


### PR DESCRIPTION
Fixes #153 

Changes:
- Pinned the `pystac-client` to `>=v0.7.0` in our `setup.py`
- Removed the `lable` from `zonalstats = earthdaily.earthdatastore.cube_utils.zonal_stats` to fix the `TestZonalStats`.