### PR TITLE
fix: restrict dask version to <2025.3.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "tqdm",
         "python-dotenv",
         "rich",
-        "dask",
+        "dask<2025.3.0",  # see: https://github.com/earthdaily/earthdaily-python-client/issues/173
         "spyndex",
         "dask-image>=2024",
         "numba",


### PR DESCRIPTION
closes #173 