### PR TITLE
release: v0.5.7

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2025-03-28
+
+### Added
+
+- `datacube` drop duplicated items and keep first item per default.
+
+### Changed
+
+- `deduplicate_items` renamed to `drop_duplicates` in search,
+now supports "first" or "last". Default is `False` (means don't drop anything).
+
+### Fixed
+
+- Requirement forces `dask<2025.3.0` due to odc-stac wrong import of `quote`.
+- Issue when `resampling` and non-native cloudmask in datacube.
+- Issue with `rescale` when different scale/offset over time.
+
 ## [0.5.6] - 2025-03-26
 
 ### Added

--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -1228,6 +1228,7 @@ class Auth:
 
                 # mask_kwargs.update(ds_mask=ds_mask)
             else:
+                
                 assets_mask = {
                     mask._native_mask_asset_mapping[
                         collections[0]
@@ -1245,12 +1246,16 @@ class Auth:
                 ds_mask = cube_utils._match_xy_dims(ds_mask, ds)
                 if intersects is not None:
                     ds_mask = ds_mask.ed.clip(intersects)
+                asset_mask_str = mask._native_mask_asset_mapping[collections[0]]
+                if asset_mask_str in ds.data_vars:
+                    ds = ds.drop_vars(asset_mask_str)
                 ds = xr.merge((ds, ds_mask), compat="override")
             Mask = mask.Mask(ds, intersects=intersects, bbox=bbox)
             if not isinstance(mask_with, str):
                 raise TypeError("mask_with must be a string")
 
             ds = getattr(Mask, mask_with)(**mask_kwargs)
+            
         # keep only one value per pixel per day
         if groupby_date:
             ds = cube_utils._groupby_date(ds, groupby_date)

--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -992,7 +992,7 @@ class Auth:
         cross_calibration_collection: None | str = None,
         properties: bool | str | list = False,
         groupby_date: str = "mean",
-        drop_duplicates: str = 'first',
+        drop_duplicates: str = "first",
         cloud_search_kwargs={},
         **kwargs,
     ) -> xr.Dataset:
@@ -1228,7 +1228,6 @@ class Auth:
 
                 # mask_kwargs.update(ds_mask=ds_mask)
             else:
-                
                 assets_mask = {
                     mask._native_mask_asset_mapping[
                         collections[0]
@@ -1255,7 +1254,7 @@ class Auth:
                 raise TypeError("mask_with must be a string")
 
             ds = getattr(Mask, mask_with)(**mask_kwargs)
-            
+
         # keep only one value per pixel per day
         if groupby_date:
             ds = cube_utils._groupby_date(ds, groupby_date)
@@ -1286,13 +1285,11 @@ class Auth:
 
             ds["clear_pixels"] = ds["clear_pixels"].load()
             ds["clear_percent"] = ds["clear_percent"].load()
-        
+
         if mask_with:
             if clear_cover:
                 ds = mask.filter_clear_cover(ds, clear_cover)
-            ds = ds.drop_vars(mask_with) 
-  
-
+            ds = ds.drop_vars(mask_with)
 
         return ds
 
@@ -1326,7 +1323,7 @@ class Auth:
         raise_no_items=True,
         batch_days="auto",
         n_jobs=-1,
-        drop_duplicates:str=False,
+        drop_duplicates: str = False,
         **kwargs,
     ):
         """
@@ -1477,7 +1474,9 @@ class Auth:
         if drop_duplicates:
             from ._filter_duplicate import filter_duplicate_items
 
-            items_collection = filter_duplicate_items(items_collection, keep=drop_duplicates)
+            items_collection = filter_duplicate_items(
+                items_collection, keep=drop_duplicates
+            )
         return items_collection
 
     def find_cloud_mask_items(

--- a/earthdaily/earthdatastore/__init__.py
+++ b/earthdaily/earthdatastore/__init__.py
@@ -992,6 +992,7 @@ class Auth:
         cross_calibration_collection: None | str = None,
         properties: bool | str | list = False,
         groupby_date: str = "mean",
+        drop_duplicates: str = 'first',
         cloud_search_kwargs={},
         **kwargs,
     ) -> xr.Dataset:
@@ -1093,7 +1094,7 @@ class Auth:
         # convert collections to list
         collections = [collections] if isinstance(collections, str) else collections
 
-        # if intersects a geometry, create a GeoDataFRame
+        # if intersects a geometry, create a GeoDataFrame
         if intersects is not None:
             intersects = cube_utils.GeometryManager(intersects).to_geopandas()
             self.intersects = intersects
@@ -1147,6 +1148,7 @@ class Auth:
             assets=assets,
             prefer_alternate=prefer_alternate,
             add_default_scale_factor=add_default_scale_factor,
+            drop_duplicates=drop_duplicates,
             **search_kwargs,
         )
 
@@ -1165,7 +1167,7 @@ class Auth:
                             "eq": cross_calibration_collection
                         },
                     },
-                    deduplicate_items=False,
+                    drop_duplicates=False,
                 )
             except Warning:
                 raise Warning(
@@ -1193,6 +1195,9 @@ class Auth:
             kwargs.pop("crs", "")
             kwargs.pop("resolution", "")
             kwargs["dtype"] = "int8"
+            kwargs["rescale"] = True
+            kwargs["resampling"] = 0
+
             if clear_cover and mask_statistics is False:
                 mask_statistics = True
             mask_kwargs = dict(mask_statistics=False)
@@ -1207,7 +1212,6 @@ class Auth:
                 ds_mask = datacube(
                     items_mask,
                     intersects=intersects,
-                    bbox=bbox,
                     groupby_date=None,
                     assets=mask_asset_mapping[mask_with],
                     **kwargs,
@@ -1229,26 +1233,24 @@ class Auth:
                         collections[0]
                     ]: mask._native_mask_def_mapping[collections[0]]
                 }
-
+                # force resampling at nearest as qualitative value.
                 ds_mask = datacube(
                     items,
+                    intersects=intersects,
                     groupby_date=None,
                     bbox=list(cube_utils.GeometryManager(intersects).to_bbox()),
                     assets=assets_mask,
-                    resampling=0,
                     **kwargs,
                 )
                 ds_mask = cube_utils._match_xy_dims(ds_mask, ds)
                 if intersects is not None:
                     ds_mask = ds_mask.ed.clip(intersects)
                 ds = xr.merge((ds, ds_mask), compat="override")
-
             Mask = mask.Mask(ds, intersects=intersects, bbox=bbox)
-
             if not isinstance(mask_with, str):
                 raise TypeError("mask_with must be a string")
-            ds = getattr(Mask, mask_with)(**mask_kwargs)
 
+            ds = getattr(Mask, mask_with)(**mask_kwargs)
         # keep only one value per pixel per day
         if groupby_date:
             ds = cube_utils._groupby_date(ds, groupby_date)
@@ -1279,10 +1281,13 @@ class Auth:
 
             ds["clear_pixels"] = ds["clear_pixels"].load()
             ds["clear_percent"] = ds["clear_percent"].load()
+        
         if mask_with:
-            ds = ds.drop_vars(mask_with)
-        if clear_cover:
-            ds = mask.filter_clear_cover(ds, clear_cover)
+            if clear_cover:
+                ds = mask.filter_clear_cover(ds, clear_cover)
+            ds = ds.drop_vars(mask_with) 
+  
+
 
         return ds
 
@@ -1316,7 +1321,7 @@ class Auth:
         raise_no_items=True,
         batch_days="auto",
         n_jobs=-1,
-        deduplicate_items=True,
+        drop_duplicates:str=False,
         **kwargs,
     ):
         """
@@ -1334,6 +1339,8 @@ class Auth:
             STAC-like filters applied on retrieved items. The default is None.
         prefer_alternate : TYPE, optional
             Prefer alternate links when available. The default is None.
+        drop_duplicates : bool, str, Optional
+            Drop duplicates. Available : "first" or "last". The default is False.
         **kwargs : TYPE
             Keyword arguments passed to the pystac client search method.
 
@@ -1462,10 +1469,10 @@ class Auth:
             items_collection = post_query_items(items_collection, post_query)
         if len(items_collection) == 0 and raise_no_items:
             raise NoItemsFoundError("No items found.")
-        if deduplicate_items:
+        if drop_duplicates:
             from ._filter_duplicate import filter_duplicate_items
 
-            items_collection = filter_duplicate_items(items_collection)
+            items_collection = filter_duplicate_items(items_collection, keep=drop_duplicates)
         return items_collection
 
     def find_cloud_mask_items(
@@ -1514,7 +1521,7 @@ class Auth:
                 collections=collections,
                 ids=ids_[items_start_idx : items_start_idx + step],
                 limit=step,
-                deduplicate_items=False,
+                drop_duplicates=False,
                 **kwargs,
             )
             items_list.extend(list(items))

--- a/earthdaily/earthdatastore/_filter_duplicate.py
+++ b/earthdaily/earthdatastore/_filter_duplicate.py
@@ -135,7 +135,7 @@ def _group_items(
     return groups
 
 
-def _deduplicate_items(items: List[Dict], keep='first') -> List[Dict]:
+def _deduplicate_items(items: List[Dict], keep="first") -> List[Dict]:
     """
     Select items with the most recent update timestamp.
 
@@ -143,7 +143,7 @@ def _deduplicate_items(items: List[Dict], keep='first') -> List[Dict]:
     ----------
     items : list[dict]
         List of STAC items
-    
+
     keep : str
         "first" or "last".
 
@@ -154,12 +154,11 @@ def _deduplicate_items(items: List[Dict], keep='first') -> List[Dict]:
     """
     if not items:
         return []
-    if len(items)==1:
+    if len(items) == 1:
         return items
-    
-    keep_idx = {"first":0,
-                 "last":-1}
-    item = [sorted(items, key=lambda x: x['id'])[keep_idx[keep]]]
+
+    keep_idx = {"first": 0, "last": -1}
+    item = [sorted(items, key=lambda x: x["id"])[keep_idx[keep]]]
     return item
 
 
@@ -167,7 +166,7 @@ def filter_duplicate_items(
     items: ItemCollection,
     time_threshold: timedelta = timedelta(minutes=60),
     method="proj:transform",
-    keep='first',
+    keep="first",
 ) -> ItemCollection:
     """
     Deduplicate STAC items based on spatial and temporal proximity.

--- a/earthdaily/earthdatastore/_filter_duplicate.py
+++ b/earthdaily/earthdatastore/_filter_duplicate.py
@@ -135,7 +135,7 @@ def _group_items(
     return groups
 
 
-def _select_latest_items(items: List[Dict]) -> List[Dict]:
+def _deduplicate_items(items: List[Dict], keep='first') -> List[Dict]:
     """
     Select items with the most recent update timestamp.
 
@@ -143,6 +143,9 @@ def _select_latest_items(items: List[Dict]) -> List[Dict]:
     ----------
     items : list[dict]
         List of STAC items
+    
+    keep : str
+        "first" or "last".
 
     Returns
     -------
@@ -151,22 +154,20 @@ def _select_latest_items(items: List[Dict]) -> List[Dict]:
     """
     if not items:
         return []
-
-    latest_timestamp = max(
-        _parse_datetime(item["properties"]["updated"]) for item in items
-    )
-
-    return [
-        item
-        for item in items
-        if _parse_datetime(item["properties"]["updated"]) == latest_timestamp
-    ]
+    if len(items)==1:
+        return items
+    
+    keep_idx = {"first":0,
+                 "last":-1}
+    item = [sorted(items, key=lambda x: x['id'])[keep_idx[keep]]]
+    return item
 
 
 def filter_duplicate_items(
     items: ItemCollection,
     time_threshold: timedelta = timedelta(minutes=60),
     method="proj:transform",
+    keep='first',
 ) -> ItemCollection:
     """
     Deduplicate STAC items based on spatial and temporal proximity.
@@ -235,7 +236,7 @@ def filter_duplicate_items(
     deduplicated = [
         item
         for group_items in grouped_items.values()
-        for item in _select_latest_items(group_items)
+        for item in _deduplicate_items(group_items, keep=keep)
     ]
     duplicates = len(items) - len(deduplicated)
     if duplicates:

--- a/earthdaily/earthdatastore/cube_utils/__init__.py
+++ b/earthdaily/earthdatastore/cube_utils/__init__.py
@@ -525,8 +525,7 @@ def rescale_assets_with_items(
             for scale, offset_data in scale_data.items():
                 for offset, times in offset_data.items():
                     asset_scaled.append(ds[[asset]].isel(time=times) * scale + offset)
-            scaled_assets.append(xr.concat(asset_scaled, dim="time"))
-
+            scaled_assets.append(xr.concat(asset_scaled, dim="time").sortby('time'))
         # Merge scaled assets
         ds_scaled = xr.merge(scaled_assets, join="override", compat="override").sortby(
             "time"

--- a/earthdaily/earthdatastore/cube_utils/__init__.py
+++ b/earthdaily/earthdatastore/cube_utils/__init__.py
@@ -525,7 +525,7 @@ def rescale_assets_with_items(
             for scale, offset_data in scale_data.items():
                 for offset, times in offset_data.items():
                     asset_scaled.append(ds[[asset]].isel(time=times) * scale + offset)
-            scaled_assets.append(xr.concat(asset_scaled, dim="time").sortby('time'))
+            scaled_assets.append(xr.concat(asset_scaled, dim="time").sortby("time"))
         # Merge scaled assets
         ds_scaled = xr.merge(scaled_assets, join="override", compat="override").sortby(
             "time"

--- a/earthdaily/earthdatastore/mask/__init__.py
+++ b/earthdaily/earthdatastore/mask/__init__.py
@@ -90,7 +90,6 @@ class Mask:
             raise ValueError(f"Asset '{cloud_asset}' needed to compute cloudmask.")
         else:
             cloud_layer = self._obj[cloud_asset].copy()
-        _assets = [a for a in self._obj.data_vars if a != cloud_asset]
 
         if fill_value:
             if labels_are_clouds:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "tqdm",
         "python-dotenv",
         "rich",
-        "dask",
+        "dask<2025.3.0",
         "spyndex",
         "dask-image>=2024",
         "numba",


### PR DESCRIPTION
## [0.5.7] - 2025-03-28

### Added

- `datacube` drop duplicated items and keep first item per default.

### Changed

- `deduplicate_items` renamed to `drop_duplicates` in search,
now supports "first" or "last". Default is `False` (means don't drop anything).

### Fixed

- Requirement forces `dask<2025.3.0` due to odc-stac wrong import of `quote`.
- Issue when `resampling` and non-native cloudmask in datacube.
- Issue with `rescale` when different scale/offset over time.
