### PR TITLE
release: v0.5.7

### DIFF
--- a/earthdaily/__init__.py
+++ b/earthdaily/__init__.py
@@ -11,7 +11,7 @@ from .accessor import (  # noqa: F401
 
 __all__ = ["options"]
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 
 def EarthDataStore(


### PR DESCRIPTION
## [0.5.7] - 2025-03-28

### Added

- `datacube` drop duplicated items and keep first item per default.

### Changed

- `deduplicate_items` renamed to `drop_duplicates` in search,
now supports "first" or "last". Default is `False` (means don't drop anything).

### Fixed

- Requirement forces `dask<2025.3.0` due to odc-stac wrong import of `quote`.
- Issue when `resampling` and non-native cloudmask in datacube.
- Issue with `rescale` when different scale/offset over time.
